### PR TITLE
docs: update README to allow free usage in open-source projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ This action performs the following operations:
 * Logs in to Sourcery using your access token
 * Reviews your code
 
-> **Note**: the Sourcery GitHub Action requires a 
-> [TEAM subscription](https://docs.sourcery.ai/Product/Plans/#team) to be used.
->
+> **Note**: the Sourcery GitHub Action is FREE for open-source projects.
+
+> **Note**: for private repositories, a 
+> [TEAM subscription](https://docs.sourcery.ai/Product/Plans/#team) is required.
 > Check out our [pricing page](https://sourcery.ai/pricing/) to sign up.
 
 ## Usage


### PR DESCRIPTION
The way it was written before, the note requiring a TEAM subscription would discourage open-source projects or enthusiasts from trying out this action.