### PR TITLE
refactor: replace `--in-place` with `--fix`

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,13 +132,13 @@ The Sourcery CLI version to use.
 
 This defaults to the latest version available.
 
-To choose a specific version (let's say `v0.12.12`):
+To choose a specific version (let's say `v1.5.0`):
 
 ```yaml
 - uses: sourcery-ai/action@v1
   with:
     token: ${{ secrets.SOURCERY_TOKEN }}
-    version: 0.12.12
+    version: 1.5.0
 ```
 
 We recommend you _not_ to this option unless strictly necessary. Pinning a Sourcery
@@ -168,13 +168,13 @@ Whether Sourcery should return an error code or not if issues are found in the c
 This defaults to `true`, and hence the Sourcery CI step will fail in case Sourcery finds
 issues in your code. You can pass `false` to prevent that behavior.
 
-### `in_place`
+### `fix`
 
 > **Type**: either `true` or `false`
 >
 > **Default**: `false`
 >
-> **CLI equivalent**: `--in-place`
+> **CLI equivalent**: `--fix`
 
 Whether Sourcery should automatically fix and modify the reviewed files in-place or not.
 

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
     default: "."
   version:
     description: >
-      Sourcery CLI version, e.g. '1.0.3'. If empty, default to the latest version 
+      Sourcery CLI version, e.g. '1.5.0'. If empty, default to the latest version 
       available.
     required: false
     default: ""
@@ -35,10 +35,17 @@ inputs:
     description: "Fail job if issues are found. Either 'true' or 'false'."
     required: false
     default: "true"
+  fix:
+    description: "Automatically fix issues where possible. Either 'true' or 'false'."
+    required: false
+    default: "false"
   in_place:
     description: "Change files in place. Either 'true' or 'false'."
     required: false
     default: "false"
+    deprecationMessage: >
+      This input is deprecated and will be removed in a future release. Please update 
+      your Sourcery `version` and use `fix` instead of `in_place`.
   config:
     description: "Location of the Sourcery YAML configuration file."
     required: false
@@ -82,6 +89,18 @@ runs:
           exit 1
         fi
 
+        if [ ${{ inputs.fix }} == "true" ]; then
+          SOURCERY_OPTIONS+=( "--fix" )
+        elif [ ${{ inputs.fix }} != "false" ]; then
+          echo "Invalid value for input 'fix'"
+          echo "Expected either 'true' or 'false'"
+          echo "Got '${{ inputs.fix }}'"
+          exit 1
+        fi
+
+        # this input is deprecated and will be removed in a future release
+        # we are keeping it here because users might have pinned Sourcery to an older
+        # version that does not support `--fix`
         if [ ${{ inputs.in_place }} == "true" ]; then
           SOURCERY_OPTIONS+=( "--in-place" )
         elif [ ${{ inputs.in_place }} != "false" ]; then


### PR DESCRIPTION
Replace the deprecated CLI option `--in-place` with the more modern `--fix`.

Note that we still support the `in_place` action input because users might have pinned `version` to an old Sourcery version that does not support `--fix` yet.

Closes https://github.com/sourcery-ai/action/issues/13.